### PR TITLE
Requires markdownlint-cli & yamllint to pass in CI before test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
 
     needs:
       - build
+      - markdownlint-cli
+      - yamllint
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Requires markdownlint-cli & yamllint to pass in CI before test