### PR TITLE
Logger handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ test: all
 	rebar3 xref
 	rebar3 dialyzer
 	rebar3 ex_doc
+	rebar3 ct
 
 .PHONY: fresh
 fresh:

--- a/README.md
+++ b/README.md
@@ -7,16 +7,6 @@
 [![License](https://img.shields.io/hexpm/l/dnsimple.svg)](https://github.com/dnsimple/bugsnag-erlang/blob/main/LICENSE.md)
 [![Last Updated](https://img.shields.io/github/last-commit/dnsimple/bugsnag-erlang.svg)](https://github.com/dnsimple/bugsnag-erlang/commits/main)
 
-## Dependencies
-
-Requires [Lager](https://github.com/erlang-lager/lager)
-
-The following applications must be started
-
-```text
-kernel,stdlib,inets,crypto,ssl,lager
-```
-
 ## Usage
 
 You may send custom errors directly
@@ -31,44 +21,35 @@ Or use the Erlang error logger
 error_logger:error_msg("A sample error caught by the bugsnag error logger.").
 ```
 
-Or cause an error with a full stack trace
+Or `logger`:
 
 ```erlang
-bugsnag:test_error().
+?LOG_ERROR(#{what => example_error, text => "A sample error caught by the bugsnag logger handler"}).
 ```
 
-When embedding, make sure to set up the configuration elements in your sys.config (or other config file)
+When embedding, make sure to set up the configuration elements in your `sys.config` (or other config file),
+See `m:bugsnag` for configuration details.
 
-  ```erlang
-  [
-    {bugsnag_erlang, [
-      {error_logger, true},
-      {api_key, "ENTER_API_KEY"},
-      {release_state, "development"}
-    ]}
-  ].
-  ```
+## Lager handler
 
-And start the application:
-
-  ```erlang
-  application:start(bugsnag)
-  ```
-
-Or add the application to your .app configuration.
-
-### Lager handler
-
-We also provide a [lager](https://github.com/basho/lager) to report anything
+We also provide a [lager](https://github.com/basho/lager) handler to report anything
 above a certain level (by default, `error`) to Bugsnag.
 
-For example, simply add
+For example, simply add to your `sys.config`
 
 ```erlang
 {bugsnag_lager_handler, critical}
 ```
 
 to your lager handler config.
+
+## Testing
+
+To test the codebase:
+
+```shell
+make test
+```
 
 ## Formatting
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,3 @@
-%%-*- mode: erlang -*-
-{cover_enabled, true}.
-
 {minimum_otp_vsn, "27"}.
 
 {erl_opts, [
@@ -19,14 +16,26 @@
     warn_export_vars,
     warn_exported_vars,
     warn_untyped_record,
-    warn_missing_spec
+    warn_missing_spec,
+    warn_missing_doc
+]}.
+
+{profiles, [
+    {test, [
+        {deps, [{meck, "~> 1.0"}]},
+        {erl_opts, [nowarn_export_all, nowarn_missing_spec, nowarn_missing_doc]},
+        {covertool, [{coverdata_files, ["eunit.coverdata", "ct.coverdata"]}]},
+        {cover_enabled, true},
+        {cover_export_enabled, true}
+    ]}
 ]}.
 
 {project_plugins, [
     {rebar3_hex, "~> 7.0"},
     {rebar3_lint, "~> 3.2"},
     {rebar3_ex_doc, "~> 0.2"},
-    {erlfmt, "~> 1.6"}
+    {erlfmt, "~> 1.6"},
+    {covertool, "~> 2.0.7"}
 ]}.
 
 {deps, [
@@ -45,11 +54,11 @@
 ]}.
 
 {xref_checks, [
-    undefined_function_calls,
-    undefined_functions,
     locals_not_used,
-    deprecated_function_calls,
-    deprecated_functions
+    undefined_functions,
+    undefined_function_calls,
+    {deprecated_function_calls, next_major_release},
+    {deprecated_functions, next_major_release}
 ]}.
 
 {hex, [{doc, #{provider => ex_doc}}]}.

--- a/src/bugsnag.erl
+++ b/src/bugsnag.erl
@@ -1,174 +1,71 @@
 -module(bugsnag).
+-moduledoc """
+BugSnag Erlang client.
 
--include_lib("kernel/include/logger.hrl").
+## Configuration
+It can be configured using application environment variables.
+```erlang
+{bugsnag_erlang, [
+    {enabled, true},
+    {api_key, "BUGSNAG_API_KEY"},
+    {release_stage, "production"}
+]}
+```
+If `enabled` is set to other than true, the rest of the configuration won't be read
+and no handler will be registered. For the rest of the keys, see `t:config/0`.
+""".
 
--behaviour(gen_server).
+-export([start_link/2]).
+-export([notify/5, notify/7]).
 
--export([start_link/2, notify/5, notify/7]).
--ignore_xref([start_link/2]).
--ifdef(TEST).
--export([test_error/0]).
--endif.
+-doc """
+Configuration options for the Bugsnag client.
 
--type opts() :: {string(), string()}.
+It takes the following configuration options:
 
--export([
-    init/1,
-    handle_call/3,
-    handle_cast/2,
-    handle_info/2
-]).
+- `api_key`: the Bugsnag API key, mandatory to provide.
+- `release_stage`: the release stage of the application, defaults to `production`
+""".
+-type config() :: #{
+    api_key := binary(),
+    release_stage := atom()
+}.
 
--record(state, {
-    api_key :: string(),
-    release_stage :: string()
-}).
--opaque state() :: #state{}.
+-export_type([config/0]).
 
--type payload() ::
-    {exception, atom(), atom() | string(), string() | binary(), atom(), non_neg_integer(), [term()],
-        term()}
-    | test_error.
-
--export_type([opts/0, state/0, payload/0]).
-
--define(NOTIFY_ENDPOINT, "https://notify.bugsnag.com").
--define(NOTIFIER_NAME, <<"Bugsnag Erlang">>).
--define(NOTIFIER_VERSION, <<"2.0.1">>).
--define(NOTIFIER_URL, <<"https://github.com/dnsimple/bugsnag-erlang">>).
-
+-doc """
+Add a new global `bugsnag_logger_handler` handler.
+""".
 -spec start_link(string(), string()) -> gen_server:start_ret().
 start_link(ApiKey, ReleaseStage) ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, {ApiKey, ReleaseStage}, []).
+    bugsnag_worker:start_link(#{
+        api_key => list_to_binary(ApiKey),
+        release_stage => list_to_existing_atom(ReleaseStage)
+    }).
 
+-doc "Notify a global worker about an exception.".
 -spec notify(atom(), atom() | string(), string() | binary(), module(), non_neg_integer()) -> ok.
 notify(Type, Reason, Message, Module, Line) ->
     notify(Type, Reason, Message, Module, Line, generate_trace(), undefined).
 
+-doc "Notify a global worker about an exception.".
 -spec notify(
     atom(), atom() | string(), string() | binary(), module(), non_neg_integer(), [term()], term()
 ) -> ok.
 notify(Type, Reason, Message, Module, Line, Trace, Request) ->
-    gen_server:cast(?MODULE, {exception, Type, Reason, Message, Module, Line, Trace, Request}).
-
--ifdef(TEST).
--spec test_error() -> ok.
-test_error() ->
-    gen_server:cast(?MODULE, test_error).
--endif.
-
-% Gen server hooks
--spec init(opts()) -> {ok, state()}.
-init({ApiKey, ReleaseStage}) ->
-    {ok, #state{api_key = ApiKey, release_stage = ReleaseStage}}.
-
--spec handle_call(term(), gen_server:from(), state()) -> {reply, ok, state()}.
-handle_call(_, _, State) ->
-    {reply, ok, State}.
-
--spec handle_cast(payload(), state()) -> {noreply, state()}.
-handle_cast({exception, Type, Reason, Message, Module, Line, Trace, Request}, State) ->
-    send_exception(Type, Reason, Message, Module, Line, Trace, Request, State),
-    {noreply, State};
-handle_cast(test_error, State) ->
-    erlang:error(test_error),
-    {noreply, State}.
-
--spec handle_info(term(), state()) -> {noreply, state()}.
-handle_info(_Message, State) ->
-    {noreply, State}.
-
-% Internal API
-
-encoder([{_, _} | _] = Value, Encode) ->
-    json:encode_key_value_list(Value, Encode);
-encoder(Other, Encode) ->
-    json:encode_value(Other, Encode).
-
-custom_encode(Value) ->
-    json:encode(Value, fun(V, Encode) -> encoder(V, Encode) end).
-
-% See https://docs.bugsnag.com/api/error-reporting/#api-reference
-send_exception(_Type, Reason, Message, _Module, _Line, Trace, _Request, State) ->
-    Payload = [
-        {'apiKey', to_bin(State#state.api_key)},
-        {'payloadVersion', <<"5">>},
-        {notifier, [
-            {name, ?NOTIFIER_NAME},
-            {version, ?NOTIFIER_VERSION},
-            {url, ?NOTIFIER_URL}
-        ]},
-        {events, [
-            [
-                {device, [
-                    {hostname, to_bin(net_adm:localhost())}
-                ]},
-                {app, [
-                    {'releaseStage', to_bin(State#state.release_stage)}
-                ]},
-                {exceptions, [
-                    [
-                        {'errorClass', to_bin(Reason)},
-                        {message, to_bin(Message)},
-                        {stacktrace, process_trace(Trace)}
-                    ]
-                ]}
-            ]
-        ]}
-    ],
-    deliver_payload(iolist_to_binary(custom_encode(Payload))).
-
-process_trace(Trace) ->
-    ?LOG_INFO(#{what => processing_trace, trace => Trace}),
-    process_trace(Trace, []).
-
-process_trace([], ProcessedTrace) ->
-    ProcessedTrace;
-process_trace([Current | Rest], ProcessedTrace) ->
-    StackTraceLine =
-        case Current of
-            {_, F, _, [{file, File}, {line, Line}]} ->
-                [
-                    {file, to_bin(File)},
-                    {'lineNumber', Line},
-                    {method, to_bin(F)}
-                ];
-            {_, F, _} ->
-                [
-                    {method, to_bin(F)}
-                ];
-            _ ->
-                ?LOG_WARNING(#{what => discarding_stack_trace_line, line => Current}),
-                []
-        end,
-    process_trace(Rest, ProcessedTrace ++ [StackTraceLine]).
-
-deliver_payload(Payload) ->
-    ?LOG_INFO(#{what => sending_exception, exception => Payload}),
-    case
-        httpc:request(
-            post, {?NOTIFY_ENDPOINT, [], "application/json", Payload}, [{timeout, 5000}], []
-        )
-    of
-        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Body}} ->
-            ?LOG_INFO(#{what => received_response, response => Body});
-        {_, {{_Version, Status, ReasonPhrase}, _Headers, _Body}} ->
-            ?LOG_WARNING(#{what => send_status_failed, status => Status, reason => ReasonPhrase})
-    end,
-
-    ok.
-
-to_bin(Atom) when erlang:is_atom(Atom) ->
-    erlang:atom_to_binary(Atom, utf8);
-to_bin(Bin) when erlang:is_binary(Bin) ->
-    Bin;
-to_bin(Int) when erlang:is_integer(Int) ->
-    erlang:integer_to_binary(Int);
-to_bin(List) when erlang:is_list(List) ->
-    erlang:iolist_to_binary(List).
+    Payload = #{
+        type => Type,
+        reason => Reason,
+        message => Message,
+        module => Module,
+        line => Line,
+        trace => Trace,
+        request => Request
+    },
+    gen_server:cast(bugsnag_worker, Payload).
 
 generate_trace() ->
-    ?LOG_INFO(#{what => generating_trace}),
+    logger:info(#{what => generating_trace}),
     try
         throw(bugsnag_gen_trace)
     catch

--- a/src/bugsnag.erl
+++ b/src/bugsnag.erl
@@ -23,8 +23,11 @@ If a new handler wants to be added, the `handler_name` key can be set to a new a
 
 """.
 
--export([start_link/2]).
+-export([start_link/2, add_handler/1, remove_handler/1]).
 -export([notify/5, notify/7]).
+-deprecated([{start_link, 2, next_major_release}]).
+-deprecated([{notify, 5, next_major_release}]).
+-deprecated([{notify, 7, next_major_release}]).
 
 -doc """
 Configuration options for the Bugsnag client.
@@ -47,8 +50,22 @@ It takes the following configuration options:
 
 -export_type([config/0]).
 
+-doc "Add a new logger handler.".
+-spec add_handler(config()) -> supervisor:startchild_ret().
+add_handler(Config) ->
+    bugsnag_sup:add_handler(Config).
+
+-doc "Remove a new logger handler.".
+-spec remove_handler(config()) -> ok | {error, term()}.
+remove_handler(#{name := Name}) ->
+    bugsnag_sup:remove_handler(Name);
+remove_handler(Name) ->
+    bugsnag_sup:remove_handler(Name).
+
 -doc """
 Add a new global `bugsnag_logger_handler` handler.
+
+This is deprecated, `add_handler/1` is preferred.
 """.
 -spec start_link(binary(), atom()) -> gen_server:start_ret().
 start_link(ApiKey, ReleaseStage) ->

--- a/src/bugsnag_app.erl
+++ b/src/bugsnag_app.erl
@@ -1,4 +1,5 @@
 -module(bugsnag_app).
+-moduledoc false.
 
 -include_lib("kernel/include/logger.hrl").
 
@@ -6,41 +7,90 @@
 
 -export([start/2, stop/1]).
 
--spec start(application:start_type(), term()) -> supervisor:startlink_ret().
+-spec start(application:start_type(), term()) -> supervisor:startlink_ret() | {error, no_api_key}.
 start(_Type, _Args) ->
-    case application:get_env(bugsnag_erlang, enabled, true) of
+    case is_enabled() of
         true ->
-            start();
+            ?LOG_INFO(#{what => starting_bugsnag}),
+            do_start();
         false ->
-            ?LOG_INFO(#{what => bugsnag_disabled}),
             %% we still need to start the sup to comply with the application behaviour
+            ?LOG_INFO(#{what => bugsnag_disabled}),
             bugsnag_sup:start_link(disabled)
-    end.
-
--spec start() -> supervisor:startlink_ret().
-start() ->
-    ?LOG_INFO(#{what => starting_bugsnag}),
-    ReleaseState =
-        case application:get_env(bugsnag_erlang, release_state) of
-            {ok, Value} -> Value;
-            undefined -> undefined
-        end,
-    case application:get_env(bugsnag_erlang, api_key) of
-        {ok, "ENTER_API_KEY"} ->
-            {error, no_api_key};
-        {ok, ApiKey} ->
-            case application:get_env(bugsnag_erlang, error_logger) of
-                {ok, true} ->
-                    error_logger:add_report_handler(bugsnag_error_logger);
-                _ ->
-                    ok
-            end,
-            bugsnag_sup:start_link({ApiKey, ReleaseState});
-        undefined ->
-            {error, no_api_key}
     end.
 
 -spec stop(_) -> ok.
 stop(_State) ->
     ?LOG_INFO(#{what => stopping_bugsnag}),
     ok.
+
+-spec do_start() -> supervisor:startlink_ret() | {error, no_api_key}.
+do_start() ->
+    case get_api_key() of
+        error ->
+            {error, no_api_key};
+        ApiKey ->
+            maybe_set_error_logger(),
+            Opts = #{
+                api_key => ApiKey,
+                release_stage => get_release_state(),
+                name => get_handler_name(),
+                pool_size => get_pool_size()
+            },
+            bugsnag_sup:start_link(Opts)
+    end.
+
+maybe_set_error_logger() ->
+    IsErrorLoggerEnabled = true =:= application:get_env(bugsnag_erlang, error_logger, false),
+    IsErrorLoggerEnabled andalso error_logger:add_report_handler(bugsnag_error_logger).
+
+-spec is_enabled() -> boolean().
+is_enabled() ->
+    true =:= application:get_env(bugsnag_erlang, enabled, true).
+
+-spec get_release_state() -> atom().
+get_release_state() ->
+    MaybeValue = application:get_env(bugsnag_erlang, release_state, production),
+    case io_lib:latin1_char_list(MaybeValue) of
+        true ->
+            list_to_existing_atom(MaybeValue);
+        false ->
+            case is_atom(MaybeValue) of
+                true -> MaybeValue;
+                false -> production
+            end
+    end.
+
+-spec get_api_key() -> binary() | error.
+get_api_key() ->
+    case application:get_env(bugsnag_erlang, api_key) of
+        undefined ->
+            error;
+        {ok, "ENTER_API_KEY"} ->
+            error;
+        {ok, Value} when is_binary(Value) ->
+            Value;
+        {ok, Value} when is_list(Value) ->
+            case io_lib:latin1_char_list(Value) of
+                true -> list_to_binary(Value);
+                false -> error
+            end
+    end.
+
+-spec get_handler_name() -> atom().
+get_handler_name() ->
+    case application:get_env(bugsnag_erlang, handler_name) of
+        undefined ->
+            bugsnag_logger_handler;
+        {ok, Value} when is_atom(Value) ->
+            Value
+    end.
+
+-spec get_pool_size() -> pos_integer().
+get_pool_size() ->
+    case application:get_env(bugsnag_erlang, pool_size) of
+        undefined ->
+            erlang:system_info(schedulers);
+        {ok, Value} when is_integer(Value), Value >= 1 ->
+            Value
+    end.

--- a/src/bugsnag_sup.erl
+++ b/src/bugsnag_sup.erl
@@ -1,34 +1,46 @@
 -module(bugsnag_sup).
+-moduledoc false.
+%% This is the top supervisor of the application, and there'll be only one of them.
+%% When adding handlers, we will add a new `m:bugsnag_handler_sup`
 
 -behaviour(supervisor).
 
--export([start_link/1]).
--export([init/1]).
+-export([start_link/1, init/1, add_handler/1, remove_handler/1]).
 
--type opts() :: disabled | {string(), string()}.
--export_type([opts/0]).
+-type config() :: disabled | bugsnag:config().
+-export_type([config/0]).
 
--spec start_link(opts()) -> supervisor:startlink_ret().
+-spec start_link(config()) -> supervisor:startlink_ret().
 start_link(Args) ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, Args).
 
--spec init(opts()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+-spec add_handler(config()) -> supervisor:startchild_ret().
+add_handler(Config) ->
+    supervisor:start_child(?MODULE, proc(Config)).
+
+-spec remove_handler(logger_handler:id()) -> ok | {error, term()}.
+remove_handler(Name) ->
+    supervisor:terminate_child(?MODULE, Name).
+
+-spec init(config()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init(Args) ->
-    Strategy = #{strategy => one_for_one, intensity => 20, period => 10},
+    Strategy = #{strategy => one_for_one, intensity => 120, period => 5},
     Children = procs(Args),
     {ok, {Strategy, Children}}.
 
--spec procs(opts()) -> [supervisor:child_spec()].
+-spec procs(config()) -> [supervisor:child_spec()].
 procs(disabled) ->
     %% bugsnag is disabled in the config
     [];
-procs({ApiKey, ReleaseState}) ->
-    Child = #{
-        id => bugsnag,
-        start => {bugsnag, start_link, [ApiKey, ReleaseState]},
+procs(Config) ->
+    [proc(Config)].
+
+proc(#{name := Name} = Config) ->
+    #{
+        id => Name,
+        start => {bugsnag_handler_sup, start_link, [Config]},
         restart => permanent,
-        shutdown => 5000,
-        type => worker,
-        modules => [bugsnag]
-    },
-    [Child].
+        shutdown => infinity,
+        type => supervisor,
+        modules => [bugsnag_handler_sup]
+    }.

--- a/src/bugsnag_worker.erl
+++ b/src/bugsnag_worker.erl
@@ -1,0 +1,175 @@
+-module(bugsnag_worker).
+-moduledoc false.
+
+-include_lib("kernel/include/logger.hrl").
+
+-behaviour(gen_server).
+
+-export([start_link/1]).
+
+-ifdef(TEST).
+-export([test_error/0]).
+-endif.
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+-record(state, {
+    api_key :: binary(),
+    release_stage :: atom()
+}).
+-opaque state() :: #state{}.
+
+-type payload() ::
+    #{
+        type := atom(),
+        reason := atom() | string(),
+        message := string() | binary(),
+        module := module(),
+        line := non_neg_integer(),
+        trace := [term()],
+        request := term()
+    }
+    | test_error.
+
+-export_type([state/0, payload/0]).
+
+-define(NOTIFY_ENDPOINT, "https://notify.bugsnag.com").
+-define(NOTIFIER_NAME, <<"Bugsnag Erlang">>).
+-define(NOTIFIER_VERSION, <<"2.0.1">>).
+-define(NOTIFIER_URL, <<"https://github.com/dnsimple/bugsnag-erlang">>).
+
+-spec start_link(bugsnag:config()) -> gen_server:start_ret().
+start_link(Config) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Config, []).
+
+-ifdef(TEST).
+-spec test_error() -> ok.
+test_error() ->
+    gen_server:cast(?MODULE, test_error).
+-endif.
+
+% Gen server hooks
+-spec init(bugsnag:config()) -> {ok, state()}.
+init(#{api_key := ApiKey, release_stage := ReleaseStage}) ->
+    {ok, #state{api_key = ApiKey, release_stage = ReleaseStage}}.
+
+-spec handle_cast(payload(), state()) -> {noreply, state()}.
+handle_cast(
+    #{
+        type := Type,
+        reason := Reason,
+        message := Message,
+        module := Module,
+        line := Line,
+        trace := Trace,
+        request := Request
+    },
+    State
+) ->
+    send_exception(Type, Reason, Message, Module, Line, Trace, Request, State),
+    {noreply, State};
+handle_cast(test_error, State) ->
+    erlang:error(test_error),
+    {noreply, State}.
+
+-spec handle_call(term(), gen_server:from(), state()) -> {reply, ok, state()}.
+handle_call(_, _, State) ->
+    {reply, ok, State}.
+
+-spec handle_info(term(), state()) -> {noreply, state()}.
+handle_info(_Message, State) ->
+    {noreply, State}.
+
+% Internal API
+
+% See https://docs.bugsnag.com/api/error-reporting/#api-reference
+send_exception(_Type, Reason, Message, _Module, _Line, Trace, _Request, State) ->
+    Payload = [
+        {'apiKey', State#state.api_key},
+        {'payloadVersion', <<"5">>},
+        {notifier, [
+            {name, ?NOTIFIER_NAME},
+            {version, ?NOTIFIER_VERSION},
+            {url, ?NOTIFIER_URL}
+        ]},
+        {events, [
+            [
+                {device, [
+                    {hostname, to_bin(net_adm:localhost())}
+                ]},
+                {app, [
+                    {'releaseStage', State#state.release_stage}
+                ]},
+                {exceptions, [
+                    [
+                        {'errorClass', to_bin(Reason)},
+                        {message, to_bin(Message)},
+                        {stacktrace, process_trace(Trace)}
+                    ]
+                ]}
+            ]
+        ]}
+    ],
+    deliver_payload(iolist_to_binary(custom_encode(Payload))).
+
+encoder([{_, _} | _] = Value, Encode) ->
+    json:encode_key_value_list(Value, Encode);
+encoder(Other, Encode) ->
+    json:encode_value(Other, Encode).
+
+custom_encode(Value) ->
+    json:encode(Value, fun(V, Encode) -> encoder(V, Encode) end).
+
+process_trace(Trace) ->
+    ?LOG_INFO(#{what => processing_trace, trace => Trace}),
+    process_trace(Trace, []).
+
+process_trace([], ProcessedTrace) ->
+    ProcessedTrace;
+process_trace([Current | Rest], ProcessedTrace) ->
+    StackTraceLine =
+        case Current of
+            {_, F, _, [{file, File}, {line, Line}]} ->
+                [
+                    {file, to_bin(File)},
+                    {'lineNumber', Line},
+                    {method, to_bin(F)}
+                ];
+            {_, F, _} ->
+                [
+                    {method, to_bin(F)}
+                ];
+            _ ->
+                ?LOG_WARNING(#{what => discarding_stack_trace_line, line => Current}),
+                []
+        end,
+    process_trace(Rest, ProcessedTrace ++ [StackTraceLine]).
+
+deliver_payload(Payload) ->
+    ?LOG_INFO(#{what => sending_exception, exception => Payload}),
+    case
+        httpc:request(
+            post, {?NOTIFY_ENDPOINT, [], "application/json", Payload}, [{timeout, 5000}], []
+        )
+    of
+        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Body}} ->
+            ?LOG_INFO(#{what => received_response, response => Body});
+        {_, {{_Version, Status, ReasonPhrase}, _Headers, _Body}} ->
+            ?LOG_WARNING(#{what => send_status_failed, status => Status, reason => ReasonPhrase})
+    end,
+
+    ok.
+
+to_bin(Atom) when erlang:is_atom(Atom) ->
+    erlang:atom_to_binary(Atom, utf8);
+to_bin(Bin) when erlang:is_binary(Bin) ->
+    Bin;
+to_bin(Int) when erlang:is_integer(Int) ->
+    erlang:integer_to_binary(Int);
+to_bin(List) when erlang:is_list(List) ->
+    erlang:iolist_to_binary(List).

--- a/src/handlers/bugsnag_logger_handler.erl
+++ b/src/handlers/bugsnag_logger_handler.erl
@@ -1,0 +1,72 @@
+-module(bugsnag_logger_handler).
+-moduledoc false.
+
+-export([log/2]).
+
+-doc "OTP logger-compliant handler for BugSnag".
+-spec log(logger:log_event(), logger:handler_config()) -> term().
+log(LogEvent, Config) ->
+    catch do_log(LogEvent, Config).
+
+%%% Helper function around `log/2'
+-spec do_log(logger:log_event(), logger:handler_config()) -> term().
+%% No mfa or line supplied in this one, we'll put in placeholders.
+do_log(#{meta := Meta} = LogEvent, Config) when not is_map_key(mfa, Meta) ->
+    NewMeta = Meta#{mfa => {undefined, undefined, 0}, line => 0},
+    do_log(LogEvent#{meta => NewMeta}, Config);
+%% Legacy report_cb logs, just apply callback
+do_log(
+    #{msg := {report, Report}, meta := #{report_cb := ReportCallback} = Meta} = LogEvent, Config
+) ->
+    Message = apply_report_callback(Report, ReportCallback),
+    NewLogEvent = LogEvent#{
+        meta => maps:without([report_cb], Meta),
+        msg => {string, Message}
+    },
+    do_log(NewLogEvent, Config);
+do_log(#{msg := {report, Report}} = LogEvent, Config) ->
+    Message = io_lib:format("~p", [Report]),
+    do_log(LogEvent#{msg => {string, Message}}, Config);
+do_log(#{msg := {Format, FormatArgs}} = LogEvent, Config) when
+    is_list(Format), is_list(FormatArgs)
+->
+    Message = io_lib:format(Format, FormatArgs),
+    do_log(LogEvent#{msg => {string, Message}}, Config);
+do_log(
+    #{
+        level := _,
+        msg := {string, Message},
+        meta := #{pid := _, time := _, mfa := {Module, _, _}, line := Line}
+    },
+    #{config := Config}
+) ->
+    Payload = #{
+        type => undefined,
+        reason => error,
+        message => Message,
+        module => Module,
+        line => Line,
+        trace => erlang:process_info(self(), current_stacktrace),
+        request => undefined
+    },
+    bugsnag_worker:notify_worker(Config, Payload);
+do_log(_LogEvent, _Config) ->
+    ok.
+
+%%% Applies a report callback function to a given report.
+-spec apply_report_callback(term(), fun()) -> iodata().
+apply_report_callback(Report, ReportCallback) ->
+    case erlang:fun_info(ReportCallback, arity) of
+        {arity, 1} ->
+            {Format, Terms} = ReportCallback(Report),
+            io_lib:format(Format, Terms);
+        {arity, 2} ->
+            ReportCallback(
+                Report,
+                #{
+                    depth => unlimited,
+                    chars_limit => unlimited,
+                    single_line => false
+                }
+            )
+    end.

--- a/src/workers/bugsnag_handler_sup.erl
+++ b/src/workers/bugsnag_handler_sup.erl
@@ -1,0 +1,65 @@
+-module(bugsnag_handler_sup).
+-moduledoc false.
+%% See `m:bugsnag_sup`.
+%%
+%% This module defines a top supervisor for the Bugsnag handler.
+%% It uses a `rest_for_one` strategy, that is, the order matters.
+%%
+%% 1. A `m:bugsnag_registry` worker responsible for creating an ETS table (and then hibernating).
+%% 2. A `m:bugsnag_worker_sup` supervising a static pool of `m:bugsnag_worker` workers.
+%% 3. A `m:bugsnag_register` worker responsible for registering the logger handler and unregistering on termination.
+%%
+%% The supervision tree is as follows
+%%
+%%                       bugsnag_sup
+%%                           |
+%%                      (dynamically)
+%%                           |
+%%                  bugsnag_handler_sup
+%%                 /         |          \
+%%                /          |           \
+%%               /           |            \
+%%  bugsnag_registry  bugsnag_worker_sup  bugsnag_register
+%%  (keeps ets table)        |            (adds and remove logger handler)
+%%                          /|\
+%%                         / | \
+%%                    [bugsnag_worker]
+
+-behaviour(supervisor).
+
+-export([start_link/1, init/1]).
+
+-spec start_link(bugsnag:config()) -> supervisor:startlink_ret().
+start_link(#{name := Name} = Config) ->
+    supervisor:start_link({local, Name}, ?MODULE, Config).
+
+-spec init(bugsnag:config()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init(Config) ->
+    Strategy = #{strategy => rest_for_one, intensity => 20, period => 10},
+    Children = [
+        #{
+            id => bugsnag_registry,
+            start => {bugsnag_registry, start_link, [Config]},
+            restart => permanent,
+            shutdown => 5000,
+            type => worker,
+            modules => [bugsnag_registry]
+        },
+        #{
+            id => bugsnag_worker_sup,
+            start => {bugsnag_worker_sup, start_link, [Config]},
+            restart => permanent,
+            shutdown => infinity,
+            type => supervisor,
+            modules => [bugsnag_worker_sup]
+        },
+        #{
+            id => bugsnag_register,
+            start => {bugsnag_register, start_link, [Config]},
+            restart => permanent,
+            shutdown => 5000,
+            type => worker,
+            modules => [bugsnag_register]
+        }
+    ],
+    {ok, {Strategy, Children}}.

--- a/src/workers/bugsnag_register.erl
+++ b/src/workers/bugsnag_register.erl
@@ -1,0 +1,30 @@
+-module(bugsnag_register).
+-moduledoc false.
+%% See `m:bugsnag_sup`.
+
+-behaviour(gen_server).
+
+-export([start_link/1, init/1, handle_call/3, handle_cast/2, terminate/2]).
+
+-spec start_link(bugsnag:config()) -> gen_server:start_ret().
+start_link(Config) ->
+    gen_server:start_link(?MODULE, Config, [{hibernate_after, 0}]).
+
+-spec init(bugsnag:config()) -> {ok, atom(), hibernate}.
+init(#{name := Name} = Config) ->
+    %% So that `terminate/2` is called
+    process_flag(trap_exit, true),
+    _ = logger:add_handler(Name, bugsnag_logger_handler, #{config => Config}),
+    {ok, Name, hibernate}.
+
+-spec handle_call(term(), gen_server:from(), atom()) -> {reply, ok, atom(), hibernate}.
+handle_call(_Request, _From, State) ->
+    {reply, ok, State, hibernate}.
+
+-spec handle_cast(term(), atom()) -> {noreply, atom(), hibernate}.
+handle_cast(_Msg, State) ->
+    {noreply, State, hibernate}.
+
+-spec terminate(term(), atom()) -> ok.
+terminate(_Reason, Name) ->
+    ok = logger:remove_handler(Name).

--- a/src/workers/bugsnag_registry.erl
+++ b/src/workers/bugsnag_registry.erl
@@ -1,0 +1,24 @@
+-module(bugsnag_registry).
+-moduledoc false.
+%% See `m:bugsnag_sup`.
+
+-behaviour(gen_server).
+
+-export([start_link/1, init/1, handle_call/3, handle_cast/2]).
+
+-spec start_link(bugsnag:config()) -> gen_server:start_ret().
+start_link(Config) ->
+    gen_server:start_link(?MODULE, Config, [{hibernate_after, 0}]).
+
+-spec init(bugsnag:config()) -> {ok, no_state, hibernate}.
+init(#{name := Name}) ->
+    _ = ets:new(Name, [named_table, public, set, {read_concurrency, true}]),
+    {ok, no_state, hibernate}.
+
+-spec handle_call(term(), gen_server:from(), no_state) -> {reply, ok, no_state, hibernate}.
+handle_call(_Request, _From, State) ->
+    {reply, ok, State, hibernate}.
+
+-spec handle_cast(term(), no_state) -> {noreply, no_state, hibernate}.
+handle_cast(_Msg, State) ->
+    {noreply, State, hibernate}.

--- a/src/workers/bugsnag_worker.erl
+++ b/src/workers/bugsnag_worker.erl
@@ -1,0 +1,194 @@
+-module(bugsnag_worker).
+-moduledoc false.
+
+-include_lib("kernel/include/logger.hrl").
+
+-behaviour(gen_server).
+
+-export([start_link/1, start_link/2, notify_worker/2]).
+
+-deprecated([{start_link, 1, "To be removed when we remove support for lager and error_logger"}]).
+
+-ifdef(TEST).
+-export([test_error/0]).
+-endif.
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+-record(state, {
+    api_key :: binary(),
+    release_stage :: atom()
+}).
+-opaque state() :: #state{}.
+
+-type payload() ::
+    #{
+        type := atom(),
+        reason := atom() | string(),
+        message := string() | binary(),
+        module := module(),
+        line := non_neg_integer(),
+        trace := [term()],
+        request := term()
+    }
+    | test_error.
+
+-export_type([state/0, payload/0]).
+
+-define(NOTIFY_ENDPOINT, "https://notify.bugsnag.com").
+-define(NOTIFIER_NAME, <<"Bugsnag Erlang">>).
+-define(NOTIFIER_VERSION, <<"2.0.1">>).
+-define(NOTIFIER_URL, <<"https://github.com/dnsimple/bugsnag-erlang">>).
+
+-spec start_link(bugsnag:config()) -> gen_server:start_ret().
+start_link(Config) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, {undefined, Config}, []).
+
+-spec start_link(pos_integer(), bugsnag:config()) -> gen_server:start_ret().
+start_link(N, Config) ->
+    gen_server:start_link(?MODULE, {N, Config}, []).
+
+-spec notify_worker(bugsnag:config(), payload()) -> ok.
+notify_worker(#{name := Name, pool_size := PoolSize}, Payload) ->
+    Int = 1 + erlang:phash2(self(), PoolSize),
+    Pid = ets:lookup_element(Name, Int, 2),
+    gen_server:cast(Pid, {payload, Payload}).
+
+-ifdef(TEST).
+-spec test_error() -> ok.
+test_error() ->
+    gen_server:cast(?MODULE, test_error).
+-endif.
+
+% Gen server hooks
+-spec init({undefined | pos_integer(), bugsnag:config()}) -> {ok, state()}.
+init({undefined, #{api_key := ApiKey, release_stage := ReleaseStage}}) ->
+    process_flag(trap_exit, true),
+    {ok, #state{api_key = ApiKey, release_stage = ReleaseStage}};
+init({N, #{name := Name, api_key := ApiKey, release_stage := ReleaseStage}}) ->
+    process_flag(trap_exit, true),
+    ets:insert(Name, {N, self()}),
+    {ok, #state{api_key = ApiKey, release_stage = ReleaseStage}}.
+
+-spec handle_cast(payload(), state()) -> {noreply, state()}.
+handle_cast(
+    #{
+        type := Type,
+        reason := Reason,
+        message := Message,
+        module := Module,
+        line := Line,
+        trace := Trace,
+        request := Request
+    },
+    State
+) ->
+    send_exception(Type, Reason, Message, Module, Line, Trace, Request, State),
+    {noreply, State};
+handle_cast(test_error, State) ->
+    erlang:error(test_error),
+    {noreply, State};
+handle_cast(_, State) ->
+    {noreply, State}.
+
+-spec handle_call(term(), gen_server:from(), state()) -> {reply, ok, state()}.
+handle_call(_, _, State) ->
+    {reply, ok, State}.
+
+-spec handle_info(term(), state()) -> {noreply, state()}.
+handle_info(_Message, State) ->
+    {noreply, State}.
+
+% Internal API
+
+% See https://docs.bugsnag.com/api/error-reporting/#api-reference
+send_exception(_Type, Reason, Message, _Module, _Line, Trace, _Request, State) ->
+    Payload = [
+        {'apiKey', State#state.api_key},
+        {'payloadVersion', <<"5">>},
+        {notifier, [
+            {name, ?NOTIFIER_NAME},
+            {version, ?NOTIFIER_VERSION},
+            {url, ?NOTIFIER_URL}
+        ]},
+        {events, [
+            [
+                {device, [
+                    {hostname, to_bin(net_adm:localhost())}
+                ]},
+                {app, [
+                    {'releaseStage', State#state.release_stage}
+                ]},
+                {exceptions, [
+                    [
+                        {'errorClass', to_bin(Reason)},
+                        {message, to_bin(Message)},
+                        {stacktrace, process_trace(Trace)}
+                    ]
+                ]}
+            ]
+        ]}
+    ],
+    deliver_payload(iolist_to_binary(custom_encode(Payload))).
+
+encoder([{_, _} | _] = Value, Encode) ->
+    json:encode_key_value_list(Value, Encode);
+encoder(Other, Encode) ->
+    json:encode_value(Other, Encode).
+
+custom_encode(Value) ->
+    json:encode(Value, fun(V, Encode) -> encoder(V, Encode) end).
+
+process_trace(Trace) ->
+    ?LOG_INFO(#{what => processing_trace, trace => Trace}),
+    process_trace(Trace, []).
+
+process_trace([], ProcessedTrace) ->
+    ProcessedTrace;
+process_trace([Current | Rest], ProcessedTrace) ->
+    StackTraceLine =
+        case Current of
+            {_, F, _, [{file, File}, {line, Line}]} ->
+                [
+                    {file, to_bin(File)},
+                    {'lineNumber', Line},
+                    {method, to_bin(F)}
+                ];
+            {_, F, _} ->
+                [
+                    {method, to_bin(F)}
+                ];
+            _ ->
+                ?LOG_WARNING(#{what => discarding_stack_trace_line, line => Current}),
+                []
+        end,
+    process_trace(Rest, ProcessedTrace ++ [StackTraceLine]).
+
+deliver_payload(Payload) ->
+    ?LOG_INFO(#{what => sending_exception, exception => Payload}),
+    case
+        httpc:request(
+            post, {?NOTIFY_ENDPOINT, [], "application/json", Payload}, [{timeout, 5000}], []
+        )
+    of
+        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Body}} ->
+            ?LOG_INFO(#{what => received_response, response => Body});
+        {_, {{_Version, Status, ReasonPhrase}, _Headers, _Body}} ->
+            ?LOG_WARNING(#{what => send_status_failed, status => Status, reason => ReasonPhrase})
+    end,
+
+    ok.
+
+to_bin(Atom) when erlang:is_atom(Atom) ->
+    erlang:atom_to_binary(Atom, utf8);
+to_bin(Bin) when erlang:is_binary(Bin) ->
+    Bin;
+to_bin(Int) when erlang:is_integer(Int) ->
+    erlang:integer_to_binary(Int);
+to_bin(List) when erlang:is_list(List) ->
+    erlang:iolist_to_binary(List).

--- a/src/workers/bugsnag_worker.erl
+++ b/src/workers/bugsnag_worker.erl
@@ -10,7 +10,7 @@
 -deprecated([{start_link, 1, "To be removed when we remove support for lager and error_logger"}]).
 
 -ifdef(TEST).
--export([test_error/0]).
+-export([deliver_payload/1, test_error/0]).
 -endif.
 
 -export([

--- a/src/workers/bugsnag_worker_sup.erl
+++ b/src/workers/bugsnag_worker_sup.erl
@@ -1,0 +1,27 @@
+-module(bugsnag_worker_sup).
+-moduledoc false.
+%% See `m:bugsnag_sup`.
+
+-behaviour(supervisor).
+
+-export([start_link/1, init/1]).
+
+-spec start_link(bugsnag:config()) -> supervisor:startlink_ret().
+start_link(Config) ->
+    supervisor:start_link(?MODULE, Config).
+
+-spec init(bugsnag:config()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init(#{pool_size := PoolSize} = Config) ->
+    Strategy = #{strategy => one_for_one, intensity => 5, period => 10},
+    Children = [
+        #{
+            id => {bugsnag_worker, N},
+            start => {bugsnag_worker, start_link, [N, Config]},
+            restart => permanent,
+            shutdown => 5000,
+            type => worker,
+            modules => [bugsnag_worker]
+        }
+     || N <- lists:seq(1, PoolSize)
+    ],
+    {ok, {Strategy, Children}}.

--- a/test/bugsnag_SUITE.erl
+++ b/test/bugsnag_SUITE.erl
@@ -1,0 +1,282 @@
+-module(bugsnag_SUITE).
+-compile([export_all, nowarn_export_all]).
+
+-behaviour(ct_suite).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-spec all() -> [ct_suite:ct_test_def()].
+all() ->
+    [
+        {group, app},
+        {group, logger}
+    ].
+
+-spec groups() -> [ct_suite:ct_group_def()].
+groups() ->
+    [
+        {app, [sequence], app_tests()},
+        {logger, [sequence], [
+            can_start_and_stop_the_default_logger,
+            can_start_and_stop_different_loggers,
+            supervision_tree_starts_successfully,
+            does_not_crash_on_bad_messages,
+            process_traps_exits,
+            all_log_events_can_be_handled
+        ]}
+    ].
+
+-spec init_per_suite(ct_suite:ct_config()) -> ct_suite:ct_config().
+init_per_suite(Config) ->
+    PrimaryLoggerConfig = logger:get_primary_config(),
+    logger:update_primary_config(#{level => all}),
+    [{primary_logger_config, PrimaryLoggerConfig} | Config].
+
+-spec end_per_suite(ct_suite:ct_config()) -> term().
+end_per_suite(Config) ->
+    PrimaryLoggerConfig = proplists:get_value(primary_logger_config, Config),
+    logger:set_primary_config(PrimaryLoggerConfig),
+    Config.
+
+-spec init_per_group(ct_suite:ct_groupname(), ct_suite:ct_config()) -> ct_suite:ct_config().
+init_per_group(app, Config) ->
+    Config;
+init_per_group(logger, Config) ->
+    application:set_env(bugsnag_erlang, enabled, false),
+    {ok, _} = application:ensure_all_started([bugsnag_erlang]),
+    Config.
+
+-spec end_per_group(ct_suite:ct_groupname(), ct_suite:ct_config()) -> term().
+end_per_group(_, _Config) ->
+    application:stop(bugsnag_erlang),
+    ok.
+
+-spec init_per_testcase(ct_suite:ct_testcase(), ct_suite:ct_config()) -> ct_suite:ct_config().
+init_per_testcase(Name, Config) ->
+    case lists:member(Name, app_tests()) of
+        true ->
+            ok;
+        false ->
+            meck:new(bugsnag_worker, [no_link, passthrough]),
+            meck:expect(bugsnag_worker, deliver_payload, fun(_) -> ok end)
+    end,
+    Config.
+
+-spec end_per_testcase(ct_suite:ct_testcase(), ct_suite:ct_config()) -> term().
+end_per_testcase(Name, _Config) ->
+    case lists:member(Name, app_tests()) of
+        true ->
+            application:unset_env(bugsnag_erlang, enabled),
+            application:unset_env(bugsnag_erlang, api_key),
+            application:stop(bugsnag_erlang);
+        false ->
+            meck:unload(bugsnag_worker)
+    end,
+    ok.
+
+app_tests() ->
+    [
+        can_start_app_with_disabled,
+        can_start_app_with_enabled,
+        fails_to_start_with_wrong_api_key,
+        can_start_with_different_release_states
+    ].
+
+%% Tests
+-spec can_start_app_with_disabled(ct_suite:ct_config()) -> term().
+can_start_app_with_disabled(_) ->
+    application:set_env(bugsnag_erlang, enabled, false),
+    {ok, _} = application:ensure_all_started([bugsnag_erlang]),
+    ?assertEqual(
+        true,
+        lists:all(
+            fun({_, Count}) -> Count =:= 0 end,
+            supervisor:count_children(bugsnag_sup)
+        )
+    ).
+
+-spec can_start_app_with_enabled(ct_suite:ct_config()) -> term().
+can_start_app_with_enabled(_) ->
+    application:set_env(bugsnag_erlang, enabled, true),
+    List = [<<"dummy">>, "dummy"],
+    Fun = fun(ApiKey) ->
+        application:set_env(bugsnag_erlang, api_key, ApiKey),
+        {ok, _} = application:ensure_all_started([bugsnag_erlang]),
+        Res = supervisor:count_children(bugsnag_sup),
+        ?assert(lists:any(fun({_, Count}) -> Count =:= 1 end, Res), Res),
+        application:stop(bugsnag_erlang)
+    end,
+    lists:foreach(Fun, List).
+
+-spec fails_to_start_with_wrong_api_key(ct_suite:ct_config()) -> term().
+fails_to_start_with_wrong_api_key(_) ->
+    application:set_env(bugsnag_erlang, enabled, true),
+    List = ["ENTER_API_KEY", undefined],
+    Fun = fun(ApiKey) ->
+        application:set_env(bugsnag_erlang, api_key, ApiKey),
+        ?assertMatch({error, _}, application:ensure_all_started([bugsnag_erlang]))
+    end,
+    lists:foreach(Fun, List).
+
+-spec can_start_with_different_release_states(ct_suite:ct_config()) -> term().
+can_start_with_different_release_states(_) ->
+    application:set_env(bugsnag_erlang, enabled, true),
+    application:set_env(bugsnag_erlang, api_key, <<"dummy">>),
+    List = [development, staging, production, test, "production"],
+    Fun = fun(ReleaseState) ->
+        application:set_env(bugsnag_erlang, release_state, ReleaseState),
+        {ok, _} = application:ensure_all_started([bugsnag_erlang]),
+        Res = supervisor:count_children(bugsnag_sup),
+        ?assert(lists:any(fun({_, Count}) -> Count =:= 1 end, Res), Res),
+        application:stop(bugsnag_erlang)
+    end,
+    lists:foreach(Fun, List).
+
+-spec can_start_and_stop_the_default_logger(ct_suite:ct_config()) -> term().
+can_start_and_stop_the_default_logger(_) ->
+    Config = #{
+        name => ?FUNCTION_NAME,
+        pool_size => 1,
+        api_key => <<"dummy">>,
+        release_stage => production
+    },
+    {ok, _Sup} = bugsnag:add_handler(Config),
+    ct:pal("We can stop any one without affecting the others"),
+    bugsnag:remove_handler(?FUNCTION_NAME),
+    ?assertMatch({error, _}, logger:get_handler_config(?FUNCTION_NAME)),
+    {comment, "Successfully stopped loggers independently of each other."}.
+
+-spec can_start_and_stop_different_loggers(ct_suite:ct_config()) -> term().
+can_start_and_stop_different_loggers(_) ->
+    Config0 = #{pool_size => 1, api_key => <<"dummy">>, release_stage => production},
+    ct:pal("After starting three loggers"),
+    ConfigA = Config0#{name => config_a},
+    ConfigB = Config0#{name => config_b},
+    ConfigC = Config0#{name => config_c},
+    {ok, _} = bugsnag:add_handler(ConfigA),
+    {ok, _} = bugsnag:add_handler(ConfigB),
+    {ok, _} = bugsnag:add_handler(ConfigC),
+    ct:pal("We can stop any one without affecting the others"),
+    bugsnag:remove_handler(ConfigC),
+    ?assertMatch({error, _}, logger:get_handler_config(config_c)),
+    ?assertMatch({ok, _}, logger:get_handler_config(config_b)),
+    ?assertMatch({ok, _}, logger:get_handler_config(config_a)),
+    bugsnag:remove_handler(ConfigB),
+    ?assertMatch({error, _}, logger:get_handler_config(config_c)),
+    ?assertMatch({error, _}, logger:get_handler_config(config_b)),
+    ?assertMatch({ok, _}, logger:get_handler_config(config_a)),
+    bugsnag:remove_handler(ConfigA),
+    ?assertMatch({error, _}, logger:get_handler_config(config_c)),
+    ?assertMatch({error, _}, logger:get_handler_config(config_b)),
+    ?assertMatch({error, _}, logger:get_handler_config(config_a)),
+    {comment, "Successfully stopped loggers independently of each other."}.
+
+-spec supervision_tree_starts_successfully(ct_suite:ct_config()) -> term().
+supervision_tree_starts_successfully(_) ->
+    Config = #{
+        name => ?FUNCTION_NAME,
+        pool_size => 12,
+        api_key => <<"dummy">>,
+        release_stage => production
+    },
+    Res = bugsnag:add_handler(Config),
+    ?assertMatch({ok, Pid} when is_pid(Pid), Res),
+    ?assertNotEqual(undefined, ets:info(?FUNCTION_NAME)).
+
+-spec does_not_crash_on_bad_messages(ct_suite:ct_config()) -> term().
+does_not_crash_on_bad_messages(_) ->
+    Config = #{
+        name => ?FUNCTION_NAME,
+        pool_size => 1,
+        api_key => <<"dummy">>,
+        release_stage => production
+    },
+    _ = bugsnag:add_handler(Config),
+    ct:pal("Sending different invalid messages to the process..."),
+    bugsnag_worker:notify_worker(Config, #{something => <<"misterious">>}),
+    bugsnag_worker:notify_worker(Config, #{ref => make_ref()}),
+    Pid = get_worker(?FUNCTION_NAME),
+    gen_server:cast(Pid, #{ref => make_ref()}),
+    gen_server:call(Pid, #{ref => make_ref()}),
+    Pid ! random_message,
+    ct:pal("We can verify that the process is still alive."),
+    ?assert(is_process_alive(Pid)),
+    {comment, "Process successfully survived invalid messages."}.
+
+-spec process_traps_exits(ct_suite:ct_config()) -> term().
+process_traps_exits(_) ->
+    Config = #{
+        name => ?FUNCTION_NAME,
+        pool_size => 1,
+        api_key => <<"dummy">>,
+        release_stage => production
+    },
+    _ = bugsnag:add_handler(Config),
+    Pid = get_worker(?FUNCTION_NAME),
+    ct:pal("Verifiying that the process won't be killed by exits:"),
+    exit(Pid, shutdown),
+    ?assert(is_process_alive(Pid)),
+    {comment, "Process successfully survived exit signals"}.
+
+-spec all_log_events_can_be_handled(ct_suite:ct_config()) -> term().
+all_log_events_can_be_handled(_) ->
+    Config = #{
+        name => ?FUNCTION_NAME,
+        pool_size => 1,
+        api_key => <<"dummy">>,
+        release_stage => production
+    },
+    _ = bugsnag:add_handler(Config),
+    Pid = get_worker(?FUNCTION_NAME),
+    generate_all_log_level_events_and_types(),
+    assert_all_log_levels_were_triggered(Pid),
+    {comment, "All log levels were triggered and successfully stored in DB."}.
+
+%% Helpers
+-spec generate_all_log_level_events_and_types() -> term().
+generate_all_log_level_events_and_types() ->
+    ct:pal("Attempt to log each severity level in different ways"),
+    logger:emergency("log_all_events: some log"),
+    ?LOG_ALERT("log_all_events: some logs ~p", [value]),
+    logger:critical("log_all_events: some log ~p", [critical]),
+    error_logger:warning_msg("log_all_events: old error logger"),
+    logger:warning([{what, #{}}]),
+    ?LOG_NOTICE(#{what => notice_this, reason => just_because, tag => log_all_events}),
+    logger:log(info, #{what => information, context => #{from => log_all_events}}),
+    ?LOG_DEBUG("log_all_events: a debug log ~p", [#{debug => true}]).
+
+-spec get_worker(atom()) -> pid().
+get_worker(Name) ->
+    ets:lookup_element(Name, 1, 2).
+
+-spec get_all_delivered_payloads(pid()) -> [term()].
+get_all_delivered_payloads(Pid) ->
+    Logs = meck:history(bugsnag_worker, Pid),
+    ct:pal("All logged events ~p~n", [Logs]),
+    Logs.
+
+-spec assert_all_log_levels_were_triggered(pid()) -> boolean().
+assert_all_log_levels_were_triggered(Pid) ->
+    Logs = get_all_delivered_payloads(Pid),
+    ?assert(7 < length(Logs)).
+
+-spec assert_has_logs(pid(), atom()) -> ok.
+assert_has_logs(Pid, FunctionName) ->
+    HasFunctionName = lists:any(
+        fun(Log) ->
+            atom_to_binary(FunctionName) =:= lists:nth(6, Log)
+        end,
+        get_all_delivered_payloads(Pid)
+    ),
+    ?assert(HasFunctionName).
+
+-spec assert_has_no_logs(pid(), atom()) -> ok.
+assert_has_no_logs(Pid, FunctionName) ->
+    HasFunctionName = lists:all(
+        fun(Log) ->
+            atom_to_binary(FunctionName) =/= lists:nth(6, Log)
+        end,
+        get_all_delivered_payloads(Pid)
+    ),
+    ?assert(HasFunctionName).


### PR DESCRIPTION
This is a big PR, that essentially rewrites a lot of the repo.

The actual preparation of payloads for bugsnag is not changed, and also gets no new tests. Changes are everywhere else.

- Split application API from the gen_server worker: `bugsnag` now only contains API, and the actual worker is moved to a separate module called `bugsnag_worker`.
- Introduce pooling, that is, we now can have a pool of `bugsnag_worker` servers, instead of a singleton, and log events will be load-balanced (`erlang:phash(self(), PoolSize)`) across the workers.
- [Introduce a `logger` handler](https://github.com/dnsimple/bugsnag-erlang/pull/30). This allows to also add more than one logger.
  - In OTP's logger, handlers can be scoped to different applications, modules, pids, log-levels, and whatnot. By being able to introduce more than one logger id, we can also configure for example different API Keys to push to different accounts, or we can configure a handler to listen to only a subset of the OTP applications in the VM.

All newly introduced code here also gets tests, coverage is almost full except for the `error_logger` and `lager` handler, and the logic that specifically converts payloads to bugsnag format and delivers them.