### PR TITLE
Split bugsnag api from worker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 Submit unit tests for your changes. You can test your changes on your machine by [running the test suite](README.md#testing):
 
-```
+```shell
 make test
 ```
 

--- a/src/bugsnag.erl
+++ b/src/bugsnag.erl
@@ -28,7 +28,7 @@ It takes the following configuration options:
 """.
 -type config() :: #{
     api_key := binary(),
-    release_stage := atom()
+    release_stage := binary()
 }.
 
 -export_type([config/0]).
@@ -36,7 +36,7 @@ It takes the following configuration options:
 -doc """
 Add a new global `bugsnag_logger_handler` handler.
 """.
--spec start_link(binary(), atom()) -> gen_server:start_ret().
+-spec start_link(binary(), binary()) -> gen_server:start_ret().
 start_link(ApiKey, ReleaseStage) ->
     bugsnag_worker:start_link(#{
         api_key => ApiKey,

--- a/src/bugsnag.erl
+++ b/src/bugsnag.erl
@@ -1,174 +1,71 @@
 -module(bugsnag).
+-moduledoc """
+BugSnag Erlang client.
 
--include_lib("kernel/include/logger.hrl").
+## Configuration
+It can be configured using application environment variables.
+```erlang
+{bugsnag_erlang, [
+    {enabled, true},
+    {api_key, "BUGSNAG_API_KEY"},
+    {release_stage, "production"}
+]}
+```
+If `enabled` is set to other than true, the rest of the configuration won't be read
+and no handler will be registered. For the rest of the keys, see `t:config/0`.
+""".
 
--behaviour(gen_server).
+-export([start_link/2]).
+-export([notify/5, notify/7]).
 
--export([start_link/2, notify/5, notify/7]).
--ignore_xref([start_link/2]).
--ifdef(TEST).
--export([test_error/0]).
--endif.
+-doc """
+Configuration options for the Bugsnag client.
 
--type opts() :: {string(), string()}.
+It takes the following configuration options:
 
--export([
-    init/1,
-    handle_call/3,
-    handle_cast/2,
-    handle_info/2
-]).
+- `api_key`: the Bugsnag API key, mandatory to provide.
+- `release_stage`: the release stage of the application, defaults to `production`
+""".
+-type config() :: #{
+    api_key := binary(),
+    release_stage := atom()
+}.
 
--record(state, {
-    api_key :: string(),
-    release_stage :: string()
-}).
--opaque state() :: #state{}.
+-export_type([config/0]).
 
--type payload() ::
-    {exception, atom(), atom() | string(), string() | binary(), atom(), non_neg_integer(), [term()],
-        term()}
-    | test_error.
-
--export_type([opts/0, state/0, payload/0]).
-
--define(NOTIFY_ENDPOINT, "https://notify.bugsnag.com").
--define(NOTIFIER_NAME, <<"Bugsnag Erlang">>).
--define(NOTIFIER_VERSION, <<"2.0.1">>).
--define(NOTIFIER_URL, <<"https://github.com/dnsimple/bugsnag-erlang">>).
-
--spec start_link(string(), string()) -> gen_server:start_ret().
+-doc """
+Add a new global `bugsnag_logger_handler` handler.
+""".
+-spec start_link(binary(), atom()) -> gen_server:start_ret().
 start_link(ApiKey, ReleaseStage) ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, {ApiKey, ReleaseStage}, []).
+    bugsnag_worker:start_link(#{
+        api_key => ApiKey,
+        release_stage => ReleaseStage
+    }).
 
+-doc "Notify a global worker about an exception.".
 -spec notify(atom(), atom() | string(), string() | binary(), module(), non_neg_integer()) -> ok.
 notify(Type, Reason, Message, Module, Line) ->
     notify(Type, Reason, Message, Module, Line, generate_trace(), undefined).
 
+-doc "Notify a global worker about an exception.".
 -spec notify(
     atom(), atom() | string(), string() | binary(), module(), non_neg_integer(), [term()], term()
 ) -> ok.
 notify(Type, Reason, Message, Module, Line, Trace, Request) ->
-    gen_server:cast(?MODULE, {exception, Type, Reason, Message, Module, Line, Trace, Request}).
-
--ifdef(TEST).
--spec test_error() -> ok.
-test_error() ->
-    gen_server:cast(?MODULE, test_error).
--endif.
-
-% Gen server hooks
--spec init(opts()) -> {ok, state()}.
-init({ApiKey, ReleaseStage}) ->
-    {ok, #state{api_key = ApiKey, release_stage = ReleaseStage}}.
-
--spec handle_call(term(), gen_server:from(), state()) -> {reply, ok, state()}.
-handle_call(_, _, State) ->
-    {reply, ok, State}.
-
--spec handle_cast(payload(), state()) -> {noreply, state()}.
-handle_cast({exception, Type, Reason, Message, Module, Line, Trace, Request}, State) ->
-    send_exception(Type, Reason, Message, Module, Line, Trace, Request, State),
-    {noreply, State};
-handle_cast(test_error, State) ->
-    erlang:error(test_error),
-    {noreply, State}.
-
--spec handle_info(term(), state()) -> {noreply, state()}.
-handle_info(_Message, State) ->
-    {noreply, State}.
-
-% Internal API
-
-encoder([{_, _} | _] = Value, Encode) ->
-    json:encode_key_value_list(Value, Encode);
-encoder(Other, Encode) ->
-    json:encode_value(Other, Encode).
-
-custom_encode(Value) ->
-    json:encode(Value, fun(V, Encode) -> encoder(V, Encode) end).
-
-% See https://docs.bugsnag.com/api/error-reporting/#api-reference
-send_exception(_Type, Reason, Message, _Module, _Line, Trace, _Request, State) ->
-    Payload = [
-        {'apiKey', to_bin(State#state.api_key)},
-        {'payloadVersion', <<"5">>},
-        {notifier, [
-            {name, ?NOTIFIER_NAME},
-            {version, ?NOTIFIER_VERSION},
-            {url, ?NOTIFIER_URL}
-        ]},
-        {events, [
-            [
-                {device, [
-                    {hostname, to_bin(net_adm:localhost())}
-                ]},
-                {app, [
-                    {'releaseStage', to_bin(State#state.release_stage)}
-                ]},
-                {exceptions, [
-                    [
-                        {'errorClass', to_bin(Reason)},
-                        {message, to_bin(Message)},
-                        {stacktrace, process_trace(Trace)}
-                    ]
-                ]}
-            ]
-        ]}
-    ],
-    deliver_payload(iolist_to_binary(custom_encode(Payload))).
-
-process_trace(Trace) ->
-    ?LOG_INFO(#{what => processing_trace, trace => Trace}),
-    process_trace(Trace, []).
-
-process_trace([], ProcessedTrace) ->
-    ProcessedTrace;
-process_trace([Current | Rest], ProcessedTrace) ->
-    StackTraceLine =
-        case Current of
-            {_, F, _, [{file, File}, {line, Line}]} ->
-                [
-                    {file, to_bin(File)},
-                    {'lineNumber', Line},
-                    {method, to_bin(F)}
-                ];
-            {_, F, _} ->
-                [
-                    {method, to_bin(F)}
-                ];
-            _ ->
-                ?LOG_WARNING(#{what => discarding_stack_trace_line, line => Current}),
-                []
-        end,
-    process_trace(Rest, ProcessedTrace ++ [StackTraceLine]).
-
-deliver_payload(Payload) ->
-    ?LOG_INFO(#{what => sending_exception, exception => Payload}),
-    case
-        httpc:request(
-            post, {?NOTIFY_ENDPOINT, [], "application/json", Payload}, [{timeout, 5000}], []
-        )
-    of
-        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Body}} ->
-            ?LOG_INFO(#{what => received_response, response => Body});
-        {_, {{_Version, Status, ReasonPhrase}, _Headers, _Body}} ->
-            ?LOG_WARNING(#{what => send_status_failed, status => Status, reason => ReasonPhrase})
-    end,
-
-    ok.
-
-to_bin(Atom) when erlang:is_atom(Atom) ->
-    erlang:atom_to_binary(Atom, utf8);
-to_bin(Bin) when erlang:is_binary(Bin) ->
-    Bin;
-to_bin(Int) when erlang:is_integer(Int) ->
-    erlang:integer_to_binary(Int);
-to_bin(List) when erlang:is_list(List) ->
-    erlang:iolist_to_binary(List).
+    Payload = #{
+        type => Type,
+        reason => Reason,
+        message => Message,
+        module => Module,
+        line => Line,
+        trace => Trace,
+        request => Request
+    },
+    gen_server:cast(bugsnag_worker, Payload).
 
 generate_trace() ->
-    ?LOG_INFO(#{what => generating_trace}),
+    logger:info(#{what => generating_trace}),
     try
         throw(bugsnag_gen_trace)
     catch

--- a/src/bugsnag_app.erl
+++ b/src/bugsnag_app.erl
@@ -35,7 +35,11 @@ start() ->
                 _ ->
                     ok
             end,
-            bugsnag_sup:start_link({ApiKey, ReleaseState});
+            Opts = #{
+                api_key => list_to_binary(ApiKey),
+                release_stage => list_to_existing_atom(ReleaseState)
+            },
+            bugsnag_sup:start_link(Opts);
         undefined ->
             {error, no_api_key}
     end.

--- a/src/bugsnag_app.erl
+++ b/src/bugsnag_app.erl
@@ -37,7 +37,7 @@ start() ->
             end,
             Opts = #{
                 api_key => list_to_binary(ApiKey),
-                release_stage => list_to_existing_atom(ReleaseState)
+                release_stage => list_to_binary(ReleaseState)
             },
             bugsnag_sup:start_link(Opts);
         undefined ->

--- a/src/bugsnag_sup.erl
+++ b/src/bugsnag_sup.erl
@@ -5,7 +5,7 @@
 -export([start_link/1]).
 -export([init/1]).
 
--type opts() :: disabled | {string(), string()}.
+-type opts() :: disabled | bugsnag:config().
 -export_type([opts/0]).
 
 -spec start_link(opts()) -> supervisor:startlink_ret().
@@ -22,13 +22,13 @@ init(Args) ->
 procs(disabled) ->
     %% bugsnag is disabled in the config
     [];
-procs({ApiKey, ReleaseState}) ->
+procs(Config) ->
     Child = #{
-        id => bugsnag,
-        start => {bugsnag, start_link, [ApiKey, ReleaseState]},
+        id => bugsnag_worker,
+        start => {bugsnag_worker, start_link, [Config]},
         restart => permanent,
         shutdown => 5000,
         type => worker,
-        modules => [bugsnag]
+        modules => [bugsnag_worker]
     },
     [Child].

--- a/src/bugsnag_worker.erl
+++ b/src/bugsnag_worker.erl
@@ -1,0 +1,175 @@
+-module(bugsnag_worker).
+-moduledoc false.
+
+-include_lib("kernel/include/logger.hrl").
+
+-behaviour(gen_server).
+
+-export([start_link/1]).
+
+-ifdef(TEST).
+-export([test_error/0]).
+-endif.
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+-record(state, {
+    api_key :: binary(),
+    release_stage :: atom()
+}).
+-opaque state() :: #state{}.
+
+-type payload() ::
+    #{
+        type := atom(),
+        reason := atom() | string(),
+        message := string() | binary(),
+        module := module(),
+        line := non_neg_integer(),
+        trace := [term()],
+        request := term()
+    }
+    | test_error.
+
+-export_type([state/0, payload/0]).
+
+-define(NOTIFY_ENDPOINT, "https://notify.bugsnag.com").
+-define(NOTIFIER_NAME, <<"Bugsnag Erlang">>).
+-define(NOTIFIER_VERSION, <<"2.0.1">>).
+-define(NOTIFIER_URL, <<"https://github.com/dnsimple/bugsnag-erlang">>).
+
+-spec start_link(bugsnag:config()) -> gen_server:start_ret().
+start_link(Config) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Config, []).
+
+-ifdef(TEST).
+-spec test_error() -> ok.
+test_error() ->
+    gen_server:cast(?MODULE, test_error).
+-endif.
+
+% Gen server hooks
+-spec init(bugsnag:config()) -> {ok, state()}.
+init(#{api_key := ApiKey, release_stage := ReleaseStage}) ->
+    {ok, #state{api_key = ApiKey, release_stage = ReleaseStage}}.
+
+-spec handle_cast(payload(), state()) -> {noreply, state()}.
+handle_cast(
+    #{
+        type := Type,
+        reason := Reason,
+        message := Message,
+        module := Module,
+        line := Line,
+        trace := Trace,
+        request := Request
+    },
+    State
+) ->
+    send_exception(Type, Reason, Message, Module, Line, Trace, Request, State),
+    {noreply, State};
+handle_cast(test_error, State) ->
+    erlang:error(test_error),
+    {noreply, State}.
+
+-spec handle_call(term(), gen_server:from(), state()) -> {reply, ok, state()}.
+handle_call(_, _, State) ->
+    {reply, ok, State}.
+
+-spec handle_info(term(), state()) -> {noreply, state()}.
+handle_info(_Message, State) ->
+    {noreply, State}.
+
+% Internal API
+
+% See https://docs.bugsnag.com/api/error-reporting/#api-reference
+send_exception(_Type, Reason, Message, _Module, _Line, Trace, _Request, State) ->
+    Payload = [
+        {'apiKey', State#state.api_key},
+        {'payloadVersion', <<"5">>},
+        {notifier, [
+            {name, ?NOTIFIER_NAME},
+            {version, ?NOTIFIER_VERSION},
+            {url, ?NOTIFIER_URL}
+        ]},
+        {events, [
+            [
+                {device, [
+                    {hostname, to_bin(net_adm:localhost())}
+                ]},
+                {app, [
+                    {'releaseStage', State#state.release_stage}
+                ]},
+                {exceptions, [
+                    [
+                        {'errorClass', to_bin(Reason)},
+                        {message, to_bin(Message)},
+                        {stacktrace, process_trace(Trace)}
+                    ]
+                ]}
+            ]
+        ]}
+    ],
+    deliver_payload(iolist_to_binary(custom_encode(Payload))).
+
+encoder([{_, _} | _] = Value, Encode) ->
+    json:encode_key_value_list(Value, Encode);
+encoder(Other, Encode) ->
+    json:encode_value(Other, Encode).
+
+custom_encode(Value) ->
+    json:encode(Value, fun(V, Encode) -> encoder(V, Encode) end).
+
+process_trace(Trace) ->
+    ?LOG_INFO(#{what => processing_trace, trace => Trace}),
+    process_trace(Trace, []).
+
+process_trace([], ProcessedTrace) ->
+    ProcessedTrace;
+process_trace([Current | Rest], ProcessedTrace) ->
+    StackTraceLine =
+        case Current of
+            {_, F, _, [{file, File}, {line, Line}]} ->
+                [
+                    {file, to_bin(File)},
+                    {'lineNumber', Line},
+                    {method, to_bin(F)}
+                ];
+            {_, F, _} ->
+                [
+                    {method, to_bin(F)}
+                ];
+            _ ->
+                ?LOG_WARNING(#{what => discarding_stack_trace_line, line => Current}),
+                []
+        end,
+    process_trace(Rest, ProcessedTrace ++ [StackTraceLine]).
+
+deliver_payload(Payload) ->
+    ?LOG_INFO(#{what => sending_exception, exception => Payload}),
+    case
+        httpc:request(
+            post, {?NOTIFY_ENDPOINT, [], "application/json", Payload}, [{timeout, 5000}], []
+        )
+    of
+        {ok, {{_Version, 200, _ReasonPhrase}, _Headers, Body}} ->
+            ?LOG_INFO(#{what => received_response, response => Body});
+        {_, {{_Version, Status, ReasonPhrase}, _Headers, _Body}} ->
+            ?LOG_WARNING(#{what => send_status_failed, status => Status, reason => ReasonPhrase})
+    end,
+
+    ok.
+
+to_bin(Atom) when erlang:is_atom(Atom) ->
+    erlang:atom_to_binary(Atom, utf8);
+to_bin(Bin) when erlang:is_binary(Bin) ->
+    Bin;
+to_bin(Int) when erlang:is_integer(Int) ->
+    erlang:integer_to_binary(Int);
+to_bin(List) when erlang:is_list(List) ->
+    erlang:iolist_to_binary(List).

--- a/src/bugsnag_worker.erl
+++ b/src/bugsnag_worker.erl
@@ -20,7 +20,7 @@
 
 -record(state, {
     api_key :: binary(),
-    release_stage :: atom()
+    release_stage :: binary()
 }).
 -opaque state() :: #state{}.
 


### PR DESCRIPTION
Keep the single responsibility principle between these two modules, and keeps the gen_server implementation isolated. Also adds some documentation :)

To be merged after #29 