### PR TITLE
Allow to granularly configure the logger handler that is given

### DIFF
--- a/src/bugsnag.erl
+++ b/src/bugsnag.erl
@@ -22,7 +22,7 @@ and no handler will be registered. For the rest of the keys, see `t:config/0`.
 If a new handler wants to be added, the `handler_name` key can be set to a new atom.
 """.
 
--export([start_link/2, add_handler/1, remove_handler/1]).
+-export([start_link/2, add_handler/1, add_handler/2, remove_handler/1]).
 -export([notify/3]).
 -export([notify/5, notify/7]).
 -deprecated([{start_link, 2, next_major_release}]).
@@ -87,7 +87,12 @@ The default `mfa` is `{undefined, undefined, 0}` and `line` is also 0.
 -doc "Add a new logger handler.".
 -spec add_handler(config()) -> supervisor:startchild_ret().
 add_handler(Config) ->
-    bugsnag_sup:add_handler(Config).
+    bugsnag_sup:add_handler(#{config => Config}).
+
+-doc "Add a new logger handler.".
+-spec add_handler(config(), logger_handler:config()) -> supervisor:startchild_ret().
+add_handler(Config, LoggerConfig) ->
+    bugsnag_sup:add_handler(LoggerConfig#{config => Config}).
 
 -doc "Remove a new logger handler.".
 -spec remove_handler(logger_handler:id() | config()) -> ok | {error, term()}.

--- a/src/bugsnag_app.erl
+++ b/src/bugsnag_app.erl
@@ -37,7 +37,7 @@ do_start() ->
                 name => get_handler_name(),
                 pool_size => get_pool_size()
             },
-            bugsnag_sup:start_link(Opts)
+            bugsnag_sup:start_link(#{config => Opts})
     end.
 
 -spec maybe_set_error_logger() -> any().

--- a/src/bugsnag_sup.erl
+++ b/src/bugsnag_sup.erl
@@ -7,16 +7,16 @@
 
 -export([start_link/1, init/1, add_handler/1, remove_handler/1]).
 
--type config() :: disabled | bugsnag:config().
+-type config() :: disabled | logger_handler:config().
 -export_type([config/0]).
 
 -spec start_link(config()) -> supervisor:startlink_ret().
 start_link(Args) ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, Args).
 
--spec add_handler(config()) -> supervisor:startchild_ret().
-add_handler(Config) ->
-    supervisor:start_child(?MODULE, proc(Config)).
+-spec add_handler(logger_handler:config()) -> supervisor:startchild_ret().
+add_handler(LoggerConfig) ->
+    supervisor:start_child(?MODULE, proc(LoggerConfig)).
 
 -spec remove_handler(logger_handler:id()) -> ok | {error, term()}.
 remove_handler(Name) ->
@@ -35,10 +35,10 @@ procs(disabled) ->
 procs(Config) ->
     [proc(Config)].
 
-proc(#{name := Name} = Config) ->
+proc(#{config := #{name := Name}} = LoggerConfig) ->
     #{
         id => Name,
-        start => {bugsnag_handler_sup, start_link, [Config]},
+        start => {bugsnag_handler_sup, start_link, [LoggerConfig]},
         restart => permanent,
         shutdown => infinity,
         type => supervisor,

--- a/src/workers/bugsnag_handler_sup.erl
+++ b/src/workers/bugsnag_handler_sup.erl
@@ -29,12 +29,12 @@
 
 -export([start_link/1, init/1]).
 
--spec start_link(bugsnag:config()) -> supervisor:startlink_ret().
-start_link(#{name := Name} = Config) ->
-    supervisor:start_link({local, Name}, ?MODULE, Config).
+-spec start_link(logger_handler:config()) -> supervisor:startlink_ret().
+start_link(#{config := #{name := Name}} = LoggerConfig) ->
+    supervisor:start_link({local, Name}, ?MODULE, LoggerConfig).
 
--spec init(bugsnag:config()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
-init(Config) ->
+-spec init(logger_handler:config()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init(#{config := Config} = LoggerConfig) ->
     Strategy = #{strategy => rest_for_one, intensity => 20, period => 10},
     Children = [
         #{
@@ -55,7 +55,7 @@ init(Config) ->
         },
         #{
             id => bugsnag_register,
-            start => {bugsnag_register, start_link, [Config]},
+            start => {bugsnag_register, start_link, [LoggerConfig]},
             restart => permanent,
             shutdown => 5000,
             type => worker,

--- a/src/workers/bugsnag_register.erl
+++ b/src/workers/bugsnag_register.erl
@@ -10,11 +10,11 @@
 start_link(Config) ->
     gen_server:start_link(?MODULE, Config, [{hibernate_after, 0}]).
 
--spec init(bugsnag:config()) -> {ok, atom(), hibernate}.
-init(#{name := Name} = Config) ->
+-spec init(logger_handler:config()) -> {ok, atom(), hibernate}.
+init(#{config := #{name := Name}} = LoggerConfig) ->
     %% So that `terminate/2` is called
     process_flag(trap_exit, true),
-    _ = logger:add_handler(Name, bugsnag_logger_handler, #{config => Config}),
+    _ = logger:add_handler(Name, bugsnag_logger_handler, LoggerConfig),
     {ok, Name, hibernate}.
 
 -spec handle_call(term(), gen_server:from(), atom()) -> {reply, ok, atom(), hibernate}.


### PR DESCRIPTION
This might be useful when it is desired to have a custom logger level filter, add formatters, and all the other things than adding a handler config allows to.

After #34 