### PR TITLE
Fix hex releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,15 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: 'ubuntu-latest'
     steps:
       - name: Check out
         uses: actions/checkout@v4
-
-      - name: Publish to Hex.pm
-        uses: erlangpack/github-action@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '27'
+          rebar3-version: '3.24'
+      - name: Publish to hex.pm
         env:
           HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+        run: rebar3 hex publish -r hexpm --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: 'ubuntu-latest'
+    runs-on: ubuntu-latest
     steps:
       - name: Check out
         uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,6 @@ The following instructions uses `$VERSION` as a placeholder, where `$VERSION` is
 
 1. Run the test suite and ensure all the tests pass.
 
-1. Set the version in `src/bugsnag_erlang.app.src` & `src/bugsnag.erl`
-
-1. Run the test suite and ensure all the tests pass.
-
 1. Finalize the `## main` section in `CHANGELOG.md` assigning the version.
 
 1. Commit and push the changes


### PR DESCRIPTION
The github actions were using OTP24, which won't work with this dependency anymore. Fixing here to manually create the package just using rebar3.