### PR TITLE
Fix getting the right version

### DIFF
--- a/src/workers/bugsnag_worker.erl
+++ b/src/workers/bugsnag_worker.erl
@@ -201,8 +201,8 @@ get_hostname() ->
 
 -spec get_version() -> binary().
 get_version() ->
-    case application:get_key(bugsnag, vsn) of
-        {ok, Vsn} when is_list(Vsn) ->
+    case lists:keyfind(bugsnag_erlang, 1, application:loaded_applications()) of
+        {bugsnag_erlang, _, Vsn} when is_list(Vsn) ->
             list_to_binary(Vsn);
         _ ->
             <<"0.0.0">>


### PR DESCRIPTION
The current code would always return version `0.0.0`, this PR fixes that to get the right version string to append to the notifier.