### PR TITLE
feat: Add optional app_version config to report app.version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+- Add optional `app_version` config key to report `app.version` to Bugsnag.
+
 ## 3.0.1
 
 - Fixed an issue with proper unicode encoding of the exception reason.

--- a/src/api/bugsnag_api_error_reporting.erl
+++ b/src/api/bugsnag_api_error_reporting.erl
@@ -166,5 +166,6 @@
     breadcrumb_type/0,
     text/0,
     severity/0,
-    severity_reason/0
+    severity_reason/0,
+    app/0
 ]).

--- a/src/bugsnag.erl
+++ b/src/bugsnag.erl
@@ -43,6 +43,7 @@ It takes the following configuration options:
     The default is 1000, as an average big event including stacktraces is no bigger than 1KB,
     therefore 1000 events should keep the payload below 1MB.
 - `notifier_name`: a string, the notifier name as required by BugSnag. Defaults to "Bugsnag Erlang".
+- `app_version`: optional, the application release version reported to Bugsnag as `app.version`.
 """.
 -type config() :: #{
     api_key := binary(),
@@ -51,7 +52,8 @@ It takes the following configuration options:
     pool_size := pos_integer(),
     endpoint => binary(),
     events_limit => pos_integer(),
-    notifier_name => binary()
+    notifier_name => binary(),
+    app_version => binary() | undefined
 }.
 
 -doc "A printable string".

--- a/src/bugsnag_app.erl
+++ b/src/bugsnag_app.erl
@@ -37,7 +37,8 @@ do_start() ->
                 name => get_handler_name(),
                 pool_size => get_pool_size(),
                 events_limit => get_events_limit(),
-                notifier_name => get_notifier_name()
+                notifier_name => get_notifier_name(),
+                app_version => get_app_version()
             },
             bugsnag_sup:start_link(#{level => Level, config => Opts})
     end.
@@ -127,4 +128,18 @@ get_notifier_name() ->
             <<"Bugsnag Erlang">>;
         {ok, Value} when is_binary(Value) ->
             Value
+    end.
+
+-spec get_app_version() -> binary() | undefined.
+get_app_version() ->
+    case application:get_env(bugsnag_erlang, app_version) of
+        {ok, Value} when is_binary(Value) ->
+            Value;
+        {ok, Value} when is_list(Value) ->
+            case io_lib:latin1_char_list(Value) of
+                true -> list_to_binary(Value);
+                false -> undefined
+            end;
+        _ ->
+            undefined
     end.

--- a/src/workers/bugsnag_worker.erl
+++ b/src/workers/bugsnag_worker.erl
@@ -109,7 +109,8 @@ send_pending(#bugsnag_state{} = State) ->
 -spec do_init(bugsnag:config()) -> {ok, state()}.
 do_init(#{api_key := ApiKey, release_stage := ReleaseStage, notifier_name := Name} = Config) ->
     process_flag(trap_exit, true),
-    Base = build_base_event(ReleaseStage),
+    AppVersion = maps:get(app_version, Config, undefined),
+    Base = build_base_event(ReleaseStage, AppVersion),
     Report = build_base_report(Name),
     {ok, #bugsnag_state{
         acc_limit = maps:get(events_limit, Config, ?NOTIFIER_ACC_LIMIT),
@@ -140,14 +141,20 @@ get_version() ->
             <<"0.0.0">>
     end.
 
--spec build_base_event(binary()) -> bugsnag_api_error_reporting:event().
-build_base_event(ReleaseStage) ->
+-spec build_base_event(binary(), binary() | undefined) -> bugsnag_api_error_reporting:event().
+build_base_event(ReleaseStage, AppVersion) ->
     {_, OsName} = os:type(),
     #{
         device => #{hostname => get_hostname(), 'osName' => OsName},
-        app => #{'releaseStage' => ReleaseStage},
+        app => build_app(ReleaseStage, AppVersion),
         exceptions => []
     }.
+
+-spec build_app(binary(), binary() | undefined) -> bugsnag_api_error_reporting:app().
+build_app(ReleaseStage, Version) when is_binary(Version) ->
+    #{'releaseStage' => ReleaseStage, version => Version};
+build_app(ReleaseStage, _) ->
+    #{'releaseStage' => ReleaseStage}.
 
 -spec build_base_report(binary()) -> bugsnag_api_error_reporting:error_report().
 build_base_report(Name) ->

--- a/test/bugsnag_SUITE.erl
+++ b/test/bugsnag_SUITE.erl
@@ -76,7 +76,8 @@ end_per_testcase(Name, _Config) ->
             application:stop(bugsnag_erlang),
             application:unset_env(bugsnag_erlang, enabled),
             application:unset_env(bugsnag_erlang, api_key),
-            application:unset_env(bugsnag_erlang, release_stage);
+            application:unset_env(bugsnag_erlang, release_stage),
+            application:unset_env(bugsnag_erlang, app_version);
         false ->
             ok
     end.
@@ -91,6 +92,7 @@ app_tests() ->
         can_start_with_handler_name,
         can_start_with_events_limit,
         can_start_with_notifier_name,
+        can_start_with_app_version,
         can_start_with_custom_log_level
     ].
 
@@ -114,6 +116,8 @@ log_messages_tests() ->
         log_different_contexts,
         log_from_worker,
         log_with_report_cb,
+        app_version_is_reported_when_configured,
+        app_version_is_absent_when_not_configured,
         verify_against_schema
     ].
 
@@ -198,6 +202,10 @@ can_start_with_events_limit(Config) ->
 -spec can_start_with_notifier_name(ct_suite:ct_config()) -> term().
 can_start_with_notifier_name(Config) ->
     can_start_with_config_key(Config, notifier_name, <<"dummy">>).
+
+-spec can_start_with_app_version(ct_suite:ct_config()) -> term().
+can_start_with_app_version(Config) ->
+    can_start_with_config_key(Config, app_version, "1.2.3").
 
 -spec can_start_with_config_key(ct_suite:ct_config(), atom(), dynamic()) -> term().
 can_start_with_config_key(Config, Key, Value) ->
@@ -377,6 +385,37 @@ log_without_meta(CtConfig) ->
     verify_schema(Schema, Logs),
     {comment, "All returned errors are validated against the schema"}.
 
+-spec app_version_is_reported_when_configured(ct_suite:ct_config()) -> term().
+app_version_is_reported_when_configured(CtConfig) ->
+    Handler = (template_handler(CtConfig, ?FUNCTION_NAME))#{app_version => <<"1.2.3">>},
+    _ = bugsnag:add_handler(Handler, #{level => error}),
+    generate_exception(bugsnag_gen_trace, std),
+    Validator = fun(ReturnValue) ->
+        [] =/= ReturnValue andalso lists:all(fun has_app_version/1, ReturnValue)
+    end,
+    {ok, Logs} = wait_helper:wait_until(
+        fun() -> get_all_delivered_payloads(CtConfig, ?FUNCTION_NAME) end,
+        expected,
+        #{no_throw => true, time_left => timer:seconds(1), sleep_time => 50, validator => Validator}
+    ),
+    verify_schema(schema(), Logs),
+    {comment, "app.version is present in the payload when app_version is configured"}.
+
+-spec app_version_is_absent_when_not_configured(ct_suite:ct_config()) -> term().
+app_version_is_absent_when_not_configured(CtConfig) ->
+    _ = bugsnag:add_handler(template_handler(CtConfig, ?FUNCTION_NAME), #{level => error}),
+    generate_exception(bugsnag_gen_trace, std),
+    Validator = fun(ReturnValue) ->
+        [] =/= ReturnValue andalso lists:all(fun has_no_app_version/1, ReturnValue)
+    end,
+    {ok, Logs} = wait_helper:wait_until(
+        fun() -> get_all_delivered_payloads(CtConfig, ?FUNCTION_NAME) end,
+        expected,
+        #{no_throw => true, time_left => timer:seconds(1), sleep_time => 50, validator => Validator}
+    ),
+    verify_schema(schema(), Logs),
+    {comment, "app.version is absent from the payload when app_version is not configured"}.
+
 -spec verify_against_schema(ct_suite:ct_config()) -> term().
 verify_against_schema(CtConfig) ->
     _ = bugsnag:add_handler(template_handler(CtConfig, ?FUNCTION_NAME)),
@@ -550,6 +589,33 @@ has_exception(
 ) ->
     true;
 has_exception(_) ->
+    false.
+
+has_app_version(
+    #{
+        <<"events">> := [
+            #{
+                <<"app">> := #{
+                    <<"releaseStage">> := _,
+                    <<"version">> := <<"1.2.3">>
+                }
+            }
+        ]
+    }
+) ->
+    true;
+has_app_version(_) ->
+    false.
+
+has_no_app_version(
+    #{
+        <<"events">> := [
+            #{<<"app">> := App} | _
+        ]
+    }
+) ->
+    not maps:is_key(<<"version">>, App);
+has_no_app_version(_) ->
     false.
 
 schema() ->


### PR DESCRIPTION
Adds an optional `app_version` application-env / handler-config key. When set
(binary or latin1 string), it populates the `app.version` field of the Bugsnag
error payload; when unset, behaviour is unchanged.

Why: I want to report the host application's release version to Bugsnag for release
tracking / regression detection. Currently the `app` object only carries
`releaseStage` and there's no way to set `app.version`.

Fully backward-compatible — no behaviour change when `app_version` is unset.